### PR TITLE
Fix gammaQgammaT dimension error

### DIFF
--- a/src/ukal.c
+++ b/src/ukal.c
@@ -126,7 +126,7 @@ FilterError_t ukal_filter_create(Filter_t * const filter,
     if (gamma->n_rows != n_states) {
         return filter_invalid_argument;
     }
-    ret_iferr( ulapack_init(&filter->gammaQgammaT, gamma->n_cols, gamma->n_cols) );
+    ret_iferr( ulapack_init(&filter->gammaQgammaT, gamma->n_rows, gamma->n_rows) );
 
     /*
      * Initialize the covariance matrix to N x N.


### PR DESCRIPTION
In the test file, dimensions of two matrices are:

```
gamma: [4, 2]
filter->gammaQgammaT: [4, 4]
```

Thus **gammaQgammaT** should be initialized with a dimension of [n_rows, n_rows] rather than [n_cols, n_cols] 

```
gamma [n_rows, n_cols]
filter->gammaQgammaT [n_rows, n_rows]
```

The test file works fine with **ULAPACK_USE_STATIC_ALLOC** because its dimension gets fixed in:

```
ret_iferr( ulapack_product(&gammaQ, &gammaT, &filter->gammaQgammaT) );

#ifdef ULAPACK_USE_STATIC_ALLOC
    result->n_rows = A->n_rows;
    result->n_cols = B->n_cols;
```

While with **ULAPACK_USE_DYNAMIC_ALLOC**, this should return an error:

```
Cannot create filter.
```

Here's my test file with dynamic memory allocation at branch **uKal-dynamic**:

https://github.com/wuhanstudio/uKal/blob/uKal-dynamic/tests/unit_test.c